### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ it is not packaged.
 
 Slightly different commands compared to the Arch Linux setup...
 ```bash
-brew install libimobiledevice usbmuxd radamsa npm frida-tools
+brew install libimobiledevice usbmuxd radamsa npm
 idevicepair pair
 npm install frida-compile
 pip3 install frida-tools


### PR DESCRIPTION
frida-tools is installed via pip3, and is not available via brew. Updated instructions for macOS to reflect this.